### PR TITLE
add a base class for all FHIR models

### DIFF
--- a/lib/bootstrap/base.rb
+++ b/lib/bootstrap/base.rb
@@ -1,0 +1,4 @@
+module FHIR
+  class Base
+  end
+end

--- a/lib/bootstrap/model.rb
+++ b/lib/bootstrap/model.rb
@@ -1,4 +1,4 @@
 module FHIR
-  class Base
+  class Model
   end
 end

--- a/lib/bootstrap/template.rb
+++ b/lib/bootstrap/template.rb
@@ -33,7 +33,7 @@ module FHIR
           type = 'module'
           type = 'class' if index==@name.length-1
           classdef = "#{space}#{type} #{name}"
-          classdef += " < FHIR::Base" if type == 'class'
+          classdef += " < FHIR::Model" if type == 'class'
           s << classdef
         end
 

--- a/lib/bootstrap/template.rb
+++ b/lib/bootstrap/template.rb
@@ -32,7 +32,9 @@ module FHIR
           space = indent(index+1,offset)
           type = 'module'
           type = 'class' if index==@name.length-1
-          s << "#{space}#{type} #{name}"
+          classdef = "#{space}#{type} #{name}"
+          classdef += " < FHIR::Base" if type == 'class'
+          s << classdef
         end
 
         # include modules


### PR DESCRIPTION
We're finding it useful, in our fork of `fhir_client`, to define class methods accessible by all FHIR models. To do this cleanly, it's easiest if they all inherit from a base class, which we're calling `FHIR::Model`.

If you like this general idea, we could move most of the stuff in `FHIR::Utilities` here, which would allow us to clean up some of the code in its `def self.included`.