### PR TITLE
move dependencies to gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,6 @@
 source "http://rubygems.org"
 gemspec
 
-gem 'rake'
-gem 'pry'
-gem 'nokogiri'
-gem 'date_time_precision'
-gem 'bcp47'
-gem 'mime-types'
-
 group :test do
   gem 'simplecov', :require => false
   gem 'minitest', "~> 4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,11 @@ PATH
   remote: .
   specs:
     fhir_models (1.0.0)
+      bcp47 (>= 0.3)
+      date_time_precision (>= 0.8)
+      mime-types (>= 1.16, < 3)
+      nokogiri (>= 1.6)
+      rake (>= 0.8.7)
 
 GEM
   remote: http://rubygems.org/
@@ -11,7 +16,7 @@ GEM
     bcp47 (0.3.3)
       i18n
     coderay (1.1.1)
-    date_time_precision (0.8.0)
+    date_time_precision (0.8.1)
     docile (1.1.5)
     i18n (0.7.0)
     json (1.8.3)
@@ -28,7 +33,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    rake (11.1.0)
+    rake (11.1.2)
     simplecov (0.11.2)
       docile (~> 1.1.0)
       json (~> 1.8)
@@ -45,14 +50,12 @@ PLATFORMS
 
 DEPENDENCIES
   awesome_print
-  bcp47
-  date_time_precision
   fhir_models!
-  mime-types
   minitest (~> 4.0)
-  nokogiri
   nokogiri-diff
   pry
-  rake
   simplecov
   turn
+
+BUNDLED WITH
+   1.10.6

--- a/fhir_models.gemspec
+++ b/fhir_models.gemspec
@@ -9,4 +9,10 @@ Gem::Specification.new do |s|
   s.authors = ["Jason Walonoski", "Andre Quina", "Rob Dingwell", "Janoo Fernandes"]
   s.version = '1.0.0'
   s.files = s.files = `git ls-files`.split("\n")
+  s.add_development_dependency 'pry'
+  s.add_dependency 'rake', '>= 0.8.7'
+  s.add_dependency 'nokogiri', '>= 1.6'
+  s.add_dependency 'date_time_precision', '>= 0.8'
+  s.add_dependency 'bcp47', '>= 0.3'
+  s.add_dependency 'mime-types', '>= 1.16', '< 3'
 end


### PR DESCRIPTION
This declares all of `fhir_models`'s explicit dependencies in its `.gemspec`, which allows other libraries to include it without restating all those sub-dependencies in their `Gemfile`s.

I made some assumptions / guesses about what versions of those gems are actually required, based on looking at `Gemfile.lock`s in this repository and some of the others it's included in. It's possible that some of the requirements are either more or less strict, and it would be good to figure out exactly. Everything seems to work locally, though.

Once this is merged, you could actually publish this on [rubygems.org](https://rubygems.org/), and we could start pointing to it without relying on Github.