### PR TITLE
Add helper class methods to FHIR::Boot::Generator

### DIFF
--- a/lib/bootstrap/generator.rb
+++ b/lib/bootstrap/generator.rb
@@ -12,6 +12,24 @@ module FHIR
       # templates keeps track of all the templates in context within a given StructureDefinition
       attr_accessor :templates
 
+      def self.lib
+        File.expand_path '..', File.dirname(File.absolute_path(__FILE__))
+      end
+
+      def self.generated?
+        # Just want to do a basic check to see if models have been generated
+        File.exists?(File.join(lib, 'fhir', 'metadata.rb')) &&
+          Dir.exists?(File.join(lib, 'fhir', 'types')) &&
+          Dir.exists?(File.join(lib, 'fhir', 'resources'))
+      end
+
+      def self.generate!
+        generator = self.new
+        generator.generate_metadata
+        generator.generate_types
+        generator.generate_resources
+      end
+
       def initialize    
         defns = File.expand_path '../../definitions',File.dirname(File.absolute_path(__FILE__))
 
@@ -47,7 +65,7 @@ module FHIR
         @templates = []
 
         # make folders for generated content if they do not exist
-        @lib = File.expand_path '..', File.dirname(File.absolute_path(__FILE__))
+        @lib = self.class.lib
         Dir.mkdir(File.join(@lib,'fhir')) if !Dir.exists?(File.join(@lib,'fhir'))
         Dir.mkdir(File.join(@lib,'fhir','types')) if !Dir.exists?(File.join(@lib,'fhir','types'))
         Dir.mkdir(File.join(@lib,'fhir','resources')) if !Dir.exists?(File.join(@lib,'fhir','resources'))
@@ -55,23 +73,6 @@ module FHIR
         # delete previously generated folder contents
         Dir.glob(File.join(@lib,'fhir','*')).each{|f|File.delete(f) if !File.directory?(f)}
         Dir.glob(File.join(@lib,'fhir','**','*')).each{|f|File.delete(f) if !File.directory?(f)}
-      end
-
-      def self.generated?
-        lib = File.expand_path '..', File.dirname(File.absolute_path(__FILE__))
-        value_set_file = File.join(lib, 'fhir', 'resources', 'ValueSet.rb')
-        File.exists?(value_set_file)
-      end
-
-      def self.generate!
-        generator = self.new
-        generator.generate!
-      end
-
-      def generate!
-        generate_metadata
-        generate_types
-        generate_resources
       end
 
       def generate_metadata

--- a/lib/bootstrap/generator.rb
+++ b/lib/bootstrap/generator.rb
@@ -57,6 +57,23 @@ module FHIR
         Dir.glob(File.join(@lib,'fhir','**','*')).each{|f|File.delete(f) if !File.directory?(f)}
       end
 
+      def self.generated?
+        lib = File.expand_path '..', File.dirname(File.absolute_path(__FILE__))
+        value_set_file = File.join(lib, 'fhir', 'resources', 'ValueSet.rb')
+        File.exists?(value_set_file)
+      end
+
+      def self.generate!
+        generator = self.new
+        generator.generate!
+      end
+
+      def generate!
+        generate_metadata
+        generate_types
+        generate_resources
+      end
+
       def generate_metadata
         template = FHIR::Boot::Template.new([],true)
         

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -7,18 +7,7 @@ namespace :fhir do
 
   desc 'generate fhir models'
   task :generate, [] do |t, args|
-    # create a generator and load the definitions
-    generator = FHIR::Boot::Generator.new
-    # 1. generate the lists of primitive data types, complex types, and resources
-    generator.generate_metadata
-    # 2. generate the complex data types
-    generator.generate_types
-    # 3. generate the base Resources
-    generator.generate_resources
-    # 4. generate extensions?
-
-    # 5. generate profiles?
-
+    FHIR::Boot::Generator.generate!
   end
 
   desc 'preprocess definitions'


### PR DESCRIPTION
As part of including this as a gem, we found we needed to ensure FHIR models were generated before doing certain initializations, and we also felt it might be nice to not require that they be regenerated every time we start the app. So we added some helper methods to `FHIR::Boot::Generator` to support that.

Let us know what you think. It is a crucial part of this gem's (thanks for publishing it, by the way!) interface.