### PR TITLE
replace $LOG with configurable FHIR.logger

### DIFF
--- a/lib/bootstrap/hashable.rb
+++ b/lib/bootstrap/hashable.rb
@@ -55,7 +55,7 @@ module FHIR
                   begin
                     obj = klass.new(child)
                   rescue Exception => e
-                    $LOG.error("Unable to inflate embedded class #{klass}\n#{e.backtrace}")
+                    FHIR.logger.error("Unable to inflate embedded class #{klass}\n#{e.backtrace}")
                   end
                 end
                 obj
@@ -68,14 +68,14 @@ module FHIR
                 obj = klass.new(value)
                 value = obj
               rescue Exception => e
-                $LOG.error("Unable to inflate embedded class #{klass}\n#{e.backtrace}")
+                FHIR.logger.error("Unable to inflate embedded class #{klass}\n#{e.backtrace}")
               end
               # if there is only one of these, but cardinality allows more, we need to wrap it in an array.              
               value = [ value ] if(value && (meta['max'] > 1))
             end
             self.instance_variable_set("@#{local_name}",value)
           elsif !FHIR::PRIMITIVES.include?(meta['type']) && meta['type']!='xhtml'
-            $LOG.error("Unhandled and unrecognized class/type: #{meta['type']}")
+            FHIR.logger.error("Unhandled and unrecognized class/type: #{meta['type']}")
           else
             # primitive
             if value.is_a?(Array)

--- a/lib/bootstrap/json.rb
+++ b/lib/bootstrap/json.rb
@@ -19,7 +19,7 @@ module FHIR
         klass = Module.const_get("FHIR::#{resourceType}")
         resource = klass.new(hash)
       rescue Exception => e
-        $LOG.error("Failed to deserialize JSON:\n#{json}\n#{e.backtrace}")
+        FHIR.logger.error("Failed to deserialize JSON:\n#{json}\n#{e.backtrace}")
         resource = nil
       end
       resource

--- a/lib/bootstrap/model.rb
+++ b/lib/bootstrap/model.rb
@@ -234,7 +234,7 @@ module FHIR
       when 'decimal'
         (!Float(value).nil? rescue false)
       else
-        $LOG.warn "Unable to check #{value} for datatype #{datatype}"
+        FHIR.logger.warn "Unable to check #{value} for datatype #{datatype}"
       end
     end
 
@@ -249,7 +249,7 @@ module FHIR
         hasRegion = (!(value =~ /-/).nil?)
         valid = !BCP47::Language.identify(value.downcase).nil? && (!hasRegion || !BCP47::Region.identify(value.upcase).nil?)
       else
-        $LOG.warn "Unable to check_binding on unknown ValueSet: #{uri}"
+        FHIR.logger.warn "Unable to check_binding on unknown ValueSet: #{uri}"
       end
       valid
     end

--- a/lib/bootstrap/xml.rb
+++ b/lib/bootstrap/xml.rb
@@ -79,7 +79,7 @@ module FHIR
         klass = Module.const_get("FHIR::#{resourceType}")
         resource = klass.new(hash)
       rescue Exception => e
-        $LOG.error("Failed to deserialize XML:\n#{xml}\n#{e.backtrace}")
+        FHIR.logger.error("Failed to deserialize XML:\n#{xml}\n#{e.backtrace}")
         resource = nil
       end
       resource

--- a/lib/fhir.rb
+++ b/lib/fhir.rb
@@ -1,4 +1,15 @@
 module FHIR
+  def self.logger
+    @logger || default_logger
+  end
+
+  def self.logger=(logger)
+    @logger = logger
+  end
+
+  def self.default_logger
+    @default_logger ||= Logger.new("fhir_models.log", 10, 1024000)
+  end
 
   def self.from_contents(contents)
     doc = Nokogiri::XML(contents)

--- a/lib/fhir_models.rb
+++ b/lib/fhir_models.rb
@@ -10,8 +10,6 @@ require 'bcp47'
 require 'bigdecimal'
 require 'logger'
 
-$LOG = Logger.new("fhir_models.log", 10, 1024000)
-
 root = File.expand_path '..', File.dirname(File.absolute_path(__FILE__))
 
 # Need to require Hashable first


### PR DESCRIPTION
Along the same lines as https://github.com/fhir-crucible/fhir_client/pull/31, this makes the logger for FHIR model generation configurable -- and more importantly, lazy-initialized. I don't think it's as important for this library as for `fhir_client`, since no patient IDs will end up in the logs, but it does prevent an empty `fhir_models.log` file from being created in our Rails app's root directory.