### PR TITLE
CodeClimate Test Reporter Deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,12 @@ rvm:
   - "2.3.1"
 script:
   - bundle exec rake test
+  - bundle exec codeclimate-test-reporter
 notifications:
   email:
     recipients:
       - healthcare-ci@googlegroups.com
     on_failure: change
 addons:
-    code_climate:
-        repo_token: 0230b3379581b30743b7b4355d7394e427648e604d19a2aba987956201eee290
+  code_climate:
+    repo_token: 0230b3379581b30743b7b4355d7394e427648e604d19a2aba987956201eee290

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,6 @@
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
-
 require 'simplecov'
+SimpleCov.start
+
 require 'nokogiri/diff'
 require 'test/unit'
 require 'pry'


### PR DESCRIPTION
Tests won't run under current master branch — Running `bundle exec rake test` alerts that there's a deprecation and exits immediately.

This updates to use the newly documented method of running Code Climate's test reporter:
https://github.com/codeclimate/ruby-test-reporter#upgrading-from-pre-10-versions

Running it without the deprecation allows the tests to run as expected.