### PR TITLE
Fix Profile Validation Cardinality Range Test

### DIFF
--- a/lib/fhir_models/fhir_ext/structure_definition.rb
+++ b/lib/fhir_models/fhir_ext/structure_definition.rb
@@ -426,7 +426,7 @@ module FHIR
           else
             element.max.to_i
           end
-        if (nodes.size < min) && (nodes.size > max)
+        if (nodes.size < min) || (nodes.size > max)
           @errors << "#{element.path} failed cardinality test (#{min}..#{max}) -- found #{nodes.size}"
         end
 


### PR DESCRIPTION
The element cardinality range test in Profile Validation has a bug and the error condition can never be met. This change performs the correct range test. 