### PR TITLE
Log errored payloads separately from error message

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -37,7 +37,7 @@ Metrics/MethodLength:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 113
+  Max: 114
 
 # Offense count: 25
 Metrics/PerceivedComplexity:

--- a/lib/fhir_models/bootstrap/json.rb
+++ b/lib/fhir_models/bootstrap/json.rb
@@ -16,7 +16,8 @@ module FHIR
         klass = Module.const_get("FHIR::#{resource_type}")
         resource = klass.new(hash)
       rescue => e
-        FHIR.logger.error("Failed to deserialize JSON:\n#{json}\n#{e.backtrace}")
+        FHIR.logger.error("Failed to deserialize JSON:\n#{e.backtrace}")
+        FHIR.logger.debug("JSON:\n#{json}")
         resource = nil
       end
       resource

--- a/lib/fhir_models/bootstrap/xml.rb
+++ b/lib/fhir_models/bootstrap/xml.rb
@@ -79,7 +79,8 @@ module FHIR
         klass = Module.const_get("FHIR::#{resource_type}")
         resource = klass.new(hash)
       rescue => e
-        FHIR.logger.error("Failed to deserialize XML:\n#{xml}\n#{e.backtrace}")
+        FHIR.logger.error("Failed to deserialize XML:\n#{e.backtrace}")
+        FHIR.logger.debug("XML:\n#{xml}")
         resource = nil
       end
       resource


### PR DESCRIPTION
When fhir-models fails at deserializing a payload (either XML or JSON),
it logs the entire payload to the FHIR::Logger at the 'error' level.

This commit changes the payload to be logged separately from the error
backtrace, and logs it at the 'debug' level instead.