### PR TITLE
Equality & comparisons

### DIFF
--- a/lib/fhir_models/bootstrap/model.rb
+++ b/lib/fhir_models/bootstrap/model.rb
@@ -15,6 +15,11 @@ module FHIR
       end
     end
 
+    # This is necessary for uniq to properly identify two FHIR models as being identical
+    def hash
+      to_hash.hash
+    end
+
     def method_missing(method, *_args, &_block)
       if defined?(self.class::MULTIPLE_TYPES) && self.class::MULTIPLE_TYPES[method.to_s]
         self.class::MULTIPLE_TYPES[method.to_s].each do |type|

--- a/lib/fhir_models/bootstrap/model.rb
+++ b/lib/fhir_models/bootstrap/model.rb
@@ -20,6 +20,12 @@ module FHIR
       to_hash.hash
     end
 
+    # allow two FHIR models to be compared for equality
+    def ==(other)
+      to_hash == other.to_hash
+    end
+    alias eql? ==
+
     def method_missing(method, *_args, &_block)
       if defined?(self.class::MULTIPLE_TYPES) && self.class::MULTIPLE_TYPES[method.to_s]
         self.class::MULTIPLE_TYPES[method.to_s].each do |type|

--- a/spec/lib/fhir_models/bootstrap/model_spec.rb
+++ b/spec/lib/fhir_models/bootstrap/model_spec.rb
@@ -1,2 +1,30 @@
 RSpec.describe 'FHIR::Model' do
+  describe '#hash' do
+    it 'should be the same for two identical fhir models' do
+      attributes = {
+        name: [
+          family: [ 'Smith' ]
+        ]
+      }
+      patient1 = FHIR::Patient.new(attributes)
+      patient2 = FHIR::Patient.new(attributes)
+      expect(patient1.hash).to eq patient2.hash
+    end
+
+    it 'should be different for two models that do not have the same attributes' do
+      attributes1 = {
+        name: [
+          family: [ 'Smith' ]
+        ]
+      }
+      attributes2 = {
+        name: [
+          family: [ 'Jones' ]
+        ]
+      }
+      patient1 = FHIR::Patient.new(attributes1)
+      patient2 = FHIR::Patient.new(attributes2)
+      expect(patient1.hash).not_to eq patient2.hash
+    end
+  end
 end

--- a/spec/lib/fhir_models/bootstrap/model_spec.rb
+++ b/spec/lib/fhir_models/bootstrap/model_spec.rb
@@ -27,4 +27,35 @@ RSpec.describe 'FHIR::Model' do
       expect(patient1.hash).not_to eq patient2.hash
     end
   end
+
+  describe '#== (alias: eql?)' do
+    it 'should be true for two identical fhir models' do
+      attributes = {
+        name: [
+          family: [ 'Smith' ]
+        ]
+      }
+      patient1 = FHIR::Patient.new(attributes)
+      patient2 = FHIR::Patient.new(attributes)
+      expect(patient1).to eq patient2
+      expect(patient1).to eql patient2
+    end
+
+    it 'should false for two models that do not have the same attributes' do
+      attributes1 = {
+        name: [
+          family: [ 'Smith' ]
+        ]
+      }
+      attributes2 = {
+        name: [
+          family: [ 'Jones' ]
+        ]
+      }
+      patient1 = FHIR::Patient.new(attributes1)
+      patient2 = FHIR::Patient.new(attributes2)
+      expect(patient1).not_to eq patient2
+      expect(patient1).not_to eql patient2
+    end
+  end
 end


### PR DESCRIPTION
This defines some methods that are needed to properly compare two `FHIR::Model`s for equality.  This will make `uniq` on an array of them work, and will also prevent inserting duplicate keys into hashes when `FHIR::Model` objects are used as keys.
 