### PR TITLE
fix equality comparisons with objects of different classes.

### DIFF
--- a/lib/fhir_models/bootstrap/model.rb
+++ b/lib/fhir_models/bootstrap/model.rb
@@ -22,7 +22,7 @@ module FHIR
 
     # allow two FHIR models to be compared for equality
     def ==(other)
-      to_hash == other.to_hash
+      self.class == other.class && to_hash == other.to_hash
     end
     alias eql? ==
 

--- a/spec/lib/fhir_models/bootstrap/model_spec.rb
+++ b/spec/lib/fhir_models/bootstrap/model_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'FHIR::Model' do
       expect(patient1).to eql patient2
     end
 
-    it 'should false for two models that do not have the same attributes' do
+    it 'should be false for two models that do not have the same attributes' do
       attributes1 = {
         name: [
           family: [ 'Smith' ]
@@ -57,5 +57,29 @@ RSpec.describe 'FHIR::Model' do
       expect(patient1).not_to eq patient2
       expect(patient1).not_to eql patient2
     end
+
+    it 'should be false when compared to a different class' do
+      attributes1 = {
+        name: [
+          family: [ 'Smith' ]
+        ]
+      }
+      patient1 = FHIR::Patient.new(attributes1)
+      patient2 = "patient 2"
+      expect(patient1).not_to eq patient2
+      expect(patient1).not_to eql patient2
+    end
+
+    it 'should be false when compared to nil' do
+      attributes1 = {
+        name: [
+          family: [ 'Smith' ]
+        ]
+      }
+      patient1 = FHIR::Patient.new(attributes1)
+      expect(patient1).not_to eq nil
+      expect(patient1).not_to be_nil
+    end
+
   end
 end


### PR DESCRIPTION
in some cases comparisons with objects of a different class would fail because the class we were comparing to did not implement the `to_hash` method (like `nil`).  This defines objects as unequal if they aren't of the same class so this won't happen.