### PR TITLE
Restore compatibility with Ruby 2.0.0 by adding default values

### DIFF
--- a/lib/fhir_models/fhir.rb
+++ b/lib/fhir_models/fhir.rb
@@ -24,7 +24,7 @@ module FHIR
   end
 
   # TODO: pull regexes from metadata
-  def self.primitive?(datatype:, value:)
+  def self.primitive?(datatype: '', value: nil)
     # Remaining data types: handle special cases before checking type StructureDefinitions
     case datatype.downcase
     when 'boolean'


### PR DESCRIPTION
Adds default values to keyword arguments in FHIR::primitive?(). This restores compatibility with Ruby 2,0,0, which requires default values if keyword arguments are used. (Ruby 2.1.0+ allows keyword arguments with no defaults)

Existing callers of this function are not affected since both arguments were required. Now both are technically optional but semantically required.