### PR TITLE
Profile Validation unit tests

### DIFF
--- a/lib/fhir_models/bootstrap/definitions.rb
+++ b/lib/fhir_models/bootstrap/definitions.rb
@@ -197,7 +197,7 @@ module FHIR
     def self.get_codes(uri)
       return nil if uri.nil?
       return @@cache[uri] if @@cache[uri]
-      valueset = expansions.select { |x| x['url'] == uri }.first || valuesets.select { |x| x['url'] == uri && x['resourceType'] == 'ValueSet' }.first
+      valueset = expansions.find { |x| x['url'] == uri } || valuesets.find { |x| x['url'] == uri && x['resourceType'] == 'ValueSet' }
       unless valueset.nil?
         @@cache[uri] = {}
         if !valueset['expansion'].nil? && !valueset['expansion']['contains'].nil?
@@ -208,16 +208,16 @@ module FHIR
         if !valueset['compose'].nil? && !valueset['compose']['include'].nil?
           # for each system, if codes are included add those, otherwise lookup the codesystem in the list
           included_systems = []
-          valueset['compose']['include'].each do |s|
-            system_url = s['system']
+          valueset['compose']['include'].each do |code_group|
+            system_url = code_group['system']
             @@cache[uri][system_url] ||= []
-            s['concept'].each { |y| @@cache[uri][system_url] << y['code'] } if s['concept']
+            code_group['concept'].each { |y| @@cache[uri][system_url] << y['code'] } if code_group['concept']
             included_systems << system_url
           end
           included_systems.each { |x| @@cache[uri][x] ||= [] }
           systems = valuesets.select { |x| x['resourceType'] == 'CodeSystem' && included_systems.include?(x['url']) }
-          systems.each do |x|
-            x['concept'].each { |y| @@cache[uri][x['url']] << y['code'] } if x['concept']
+          systems.each do |included_system|
+            included_system['concept'].each { |y| @@cache[uri][included_system['url']] << y['code'] } if included_system['concept']
           end
         end
         @@cache[uri].each { |_system, codes| codes.uniq! }

--- a/lib/fhir_models/bootstrap/definitions.rb
+++ b/lib/fhir_models/bootstrap/definitions.rb
@@ -198,7 +198,6 @@ module FHIR
       return nil if uri.nil?
       return @@cache[uri] if @@cache[uri]
       valueset = expansions.select { |x| x['url'] == uri }.first || valuesets.select { |x| x['url'] == uri && x['resourceType'] == 'ValueSet' }.first
-      # binding.pry if uri == 'http://hl7.org/fhir/ValueSet/fips-county'
       unless valueset.nil?
         @@cache[uri] = {}
         if !valueset['expansion'].nil? && !valueset['expansion']['contains'].nil?

--- a/lib/fhir_models/bootstrap/definitions.rb
+++ b/lib/fhir_models/bootstrap/definitions.rb
@@ -197,7 +197,8 @@ module FHIR
     def self.get_codes(uri)
       return nil if uri.nil?
       return @@cache[uri] if @@cache[uri]
-      valueset = expansions.select { |x| x['url'] == uri }.first
+      valueset = expansions.select { |x| x['url'] == uri }.first || valuesets.select { |x| x['url'] == uri && x['resourceType'] == 'ValueSet' }.first
+      # binding.pry if uri == 'http://hl7.org/fhir/ValueSet/fips-county'
       unless valueset.nil?
         @@cache[uri] = {}
         if !valueset['expansion'].nil? && !valueset['expansion']['contains'].nil?
@@ -206,8 +207,15 @@ module FHIR
           valueset['expansion']['contains'].each { |x| @@cache[uri][x['system']] << x['code'] }
         end
         if !valueset['compose'].nil? && !valueset['compose']['include'].nil?
-          included_systems = valueset['compose']['include'].map { |x| x['system'] }.uniq
-          included_systems.each { |x| @@cache[uri][x] = [] unless @@cache[uri].keys.include?(x) }
+          # for each system, if codes are included add those, otherwise lookup the codesystem in the list
+          included_systems = []
+          valueset['compose']['include'].each do |s|
+            system_url = s['system']
+            @@cache[uri][system_url] ||= []
+            s['concept'].each { |y| @@cache[uri][system_url] << y['code'] } if s['concept']
+            included_systems << system_url
+          end
+          included_systems.each { |x| @@cache[uri][x] ||= [] }
           systems = valuesets.select { |x| x['resourceType'] == 'CodeSystem' && included_systems.include?(x['url']) }
           systems.each do |x|
             x['concept'].each { |y| @@cache[uri][x['url']] << y['code'] } if x['concept']

--- a/lib/fhir_models/fhir_ext/structure_definition.rb
+++ b/lib/fhir_models/fhir_ext/structure_definition.rb
@@ -113,9 +113,9 @@ module FHIR
       path = element.local_name || element.path
       path = path[(@hierarchy.path.size + 1)..-1] if path.start_with? @hierarchy.path
 
-      begin
+      if element.type && !element.type.empty?
         data_type_found = element.type.first.code
-      rescue
+      else
         @warnings << "Unable to guess data type for #{describe_element(element)}"
         data_type_found = nil
       end
@@ -239,13 +239,11 @@ module FHIR
       # Check the cardinality
       min = element.min
       max = element.max == '*' ? Float::INFINITY : element.max.to_i
-      return unless (nodes.size < min) || (nodes.size > max)
-      @errors << "#{describe_element(element)} failed cardinality test (#{min}..#{max}) -- found #{nodes.size}"
+      @errors << "#{describe_element(element)} failed cardinality test (#{min}..#{max}) -- found #{nodes.size}" if (nodes.size < min) || (nodes.size > max)
     end
 
     def verify_fixed_value(element, value)
-      return unless !element.fixed.nil? && element.fixed != value
-      @errors << "#{describe_element(element)} value of '#{value}' did not match fixed value: #{element.fixed}"
+      @errors << "#{describe_element(element)} value of '#{value}' did not match fixed value: #{element.fixed}" if !element.fixed.nil? && element.fixed != value
     end
 
     # data_type_code == a FHIR DataType code (see http://hl7.org/fhir/2015May/datatypes.html)

--- a/lib/fhir_models/fhir_ext/structure_definition.rb
+++ b/lib/fhir_models/fhir_ext/structure_definition.rb
@@ -357,7 +357,7 @@ module FHIR
           end
         end
       elsif !valueset.values.flatten.include?(value)
-        message = "#{element.path} has invalid code '#{value}' from #{valueset}"
+        message = "#{element.path} has invalid code '#{value}' from #{vs_uri}"
         if element.binding.strength == 'required'
           @errors << message
           matching_type -= 1
@@ -372,9 +372,8 @@ module FHIR
     def some_type_of_xml_or_json?(code)
       m = code.downcase
       return true if m == 'xml' || m == 'json'
-      return true if (m.starts_with?('application/') || m.starts_with?('text/')) && (m.ends_with?('json') || m.ends_with?('xml'))
-      return true if m.starts_with?('application/xml') || m.starts_with?('text/xml')
-      return true if m.starts_with?('application/json') || m.starts_with?('text/json')
+      return true if m.start_with?('application/', 'text/') && m.end_with?('json', 'xml')
+      return true if m.start_with?('application/xml', 'text/xml', 'application/json', 'text/json')
       false
     end
     deprecate :is_some_type_of_xml_or_json, :some_type_of_xml_or_json?


### PR DESCRIPTION
Adds some unit tests for the profile validation logic, and fixes a few issues identified by those tests.

Short description of the changes:
 - in StructureDefinition:
   - extracted some logic to separate functions to make it easier to unit test
   - moved the "unable to guess data type" message as it was unreachable previously
   - fixed a couple array operators & function names
   - rubocop suggestions
 - in Definitions.get_codes, the function would only get a code from an expansion, not any value set. Most value sets have expansions in the expansions file, but not all of them. The change adds a fallback to pick codes from the valuesets.json resource if there is no expansion. (example VS: http://hl7.org/fhir/ValueSet/fips-county )