### PR TITLE
remove restriction on mime type dependency. 

### DIFF
--- a/fhir_models.gemspec
+++ b/fhir_models.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'nokogiri', '>= 1.6'
   spec.add_dependency 'date_time_precision', '>= 0.8'
   spec.add_dependency 'bcp47', '>= 0.3'
-  spec.add_dependency 'mime-types', '>= 1.16', '< 3'
+  spec.add_dependency 'mime-types', '>= 1.16'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
Not sure why the restriction is there but it causes problems for projects using newer versions.  This simply removes the restriction.