### PR TITLE
Porting recent fhir_dstu2_model changes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
     - 'spec/**/*'
     - 'lib/fhir_models/fhir/**/*'
     - 'lib/fhir_models/fluentpath/evaluate.rb'
+    - 'lib/**/*.rake'
     - 'tmp/**/*'
     - '*.gemspec'
     - 'bin/*'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -27,7 +27,7 @@ Metrics/BlockLength:
 # Offense count: 1
 # Configuration parameters: CountBlocks.
 Metrics/BlockNesting:
-  Max: 4
+  Max: 8
 
 # Offense count: 5
 # Configuration parameters: CountComments.
@@ -41,7 +41,7 @@ Metrics/CyclomaticComplexity:
 # Offense count: 40
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
-  Max: 109
+  Max: 150
 
 # Offense count: 1
 # Configuration parameters: CountComments.

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: ruby
 env:
   - TESTMEMORY=0 GCDELAY=2.0
 rvm:
-  - 2.2
   - 2.3
   - 2.4
   - 2.5
+  - 2.6
 script:
   - bundle exec rake
   - bundle exec codeclimate-test-reporter

--- a/fhir_models.gemspec
+++ b/fhir_models.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'nokogiri', '>= 1.8.2'
   spec.add_dependency 'date_time_precision', '>= 0.8'
   spec.add_dependency 'bcp47', '>= 0.3'
-  spec.add_dependency 'mime-types', '>= 1.16', '< 3'
+  spec.add_dependency 'mime-types', '>= 3.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/lib/fhir_models/bootstrap/hashable.rb
+++ b/lib/fhir_models/bootstrap/hashable.rb
@@ -111,7 +111,7 @@ module FHIR
       elsif FHIR::PRIMITIVES.include?(meta['type'])
         primitive_meta = FHIR::PRIMITIVES[meta['type']]
         if primitive_meta['type'] == 'number'
-          rval = BigDecimal.new(value.to_s)
+          rval = BigDecimal(value.to_s)
           rval = rval.frac.zero? ? rval.to_i : rval.to_f
         end # primitive is number
       end # boolean else

--- a/lib/fhir_models/bootstrap/hashable.rb
+++ b/lib/fhir_models/bootstrap/hashable.rb
@@ -51,7 +51,7 @@ module FHIR
         if !klass.nil? && !value.nil?
           # handle array of objects
           if value.is_a?(Array)
-            value.map! do |child|
+            value = value.map do |child|
               obj = child
               unless [FHIR::RESOURCES, FHIR::TYPES].flatten.include? child.class.name.gsub('FHIR::', '')
                 obj = make_child(child, klass)
@@ -68,7 +68,7 @@ module FHIR
           FHIR.logger.error("Unhandled and unrecognized class/type: #{meta['type']}")
         elsif value.is_a?(Array)
           # array of primitives
-          value.map! { |child| convert_primitive(child, meta) }
+          value = value.map { |child| convert_primitive(child, meta) }
           instance_variable_set("@#{local_name}", value)
         else
           # single primitive

--- a/lib/fhir_models/bootstrap/model.rb
+++ b/lib/fhir_models/bootstrap/model.rb
@@ -200,8 +200,8 @@ module FHIR
           else
             errors[field] << "#{meta['path']}: expected Reference, found #{klassname}"
           end
-        # if the data type is a particular resource or complex type
-        elsif FHIR::RESOURCES.include?(datatype) || FHIR::TYPES.include?(datatype)
+        # if the data type is a particular resource or complex type or BackBone element within this resource
+        elsif FHIR::RESOURCES.include?(datatype) || FHIR::TYPES.include?(datatype) || v.class.name.start_with?(self.class.name)
           if datatype == klassname
             validation = v.validate(contained_here)
             errors[field] << validation unless validation.empty?

--- a/lib/fhir_models/examples/json/capabilitystatement-example.json
+++ b/lib/fhir_models/examples/json/capabilitystatement-example.json
@@ -216,7 +216,7 @@
       "mode": "consumer",
       "documentation": "Basic rules for all documents in the EHR system",
       "profile": {
-        "reference": "http://fhir.hl7.org/base/Profilebc054d23-75e1-4dc6-aca5-838b6b1ac81d/_history/b5fdd9fc-b021-4ea1-911a-721a60663796"
+        "reference": "http://fhir.hl7.org/StructureDefinition/Profilebc054d23-75e1-4dc6-aca5-838b6b1ac81d/_history/b5fdd9fc-b021-4ea1-911a-721a60663796"
       }
     }
   ]

--- a/lib/fhir_models/examples/json/claim-example-oral-contained-identifier.json
+++ b/lib/fhir_models/examples/json/claim-example-oral-contained-identifier.json
@@ -109,7 +109,7 @@
       "sequence": 1,
       "focal": true,
       "coverage": {
-        "reference": "http://www.jurisdiction.com/nationalplan/123AB345"
+        "reference": "http://www.jurisdiction.com/Coverage/123AB345"
       }
     }
   ],

--- a/lib/fhir_models/examples/json/dataelement-example.json
+++ b/lib/fhir_models/examples/json/dataelement-example.json
@@ -186,7 +186,7 @@
       "mapping": [
         {
           "identity": "fhir",
-          "language": "application/xquery",
+          "language": "application/xml",
           "map": "return f:/Patient/f:gender"
         }
       ]

--- a/lib/fhir_models/examples/json/endpoint-examples-general-template.json
+++ b/lib/fhir_models/examples/json/endpoint-examples-general-template.json
@@ -199,7 +199,7 @@
           }
         ],
         "payloadMimeType": [
-          "PDF"
+          "application/pdf"
         ],
         "address": "https://sqlonfhir-dstu2.azurewebsites.net/fhir"
       }
@@ -232,7 +232,7 @@
           }
         ],
         "payloadMimeType": [
-          "HL7v2"
+          "application/fhir+json"
         ],
         "address": "127.0.0.1"
       }
@@ -265,7 +265,7 @@
           }
         ],
         "payloadMimeType": [
-          "XDA/XDS"
+          "application/xml"
         ],
         "address": "https://open.epic.com/Interface/XDS.b"
       }
@@ -298,7 +298,7 @@
           }
         ],
         "payloadMimeType": [
-          "DICOM WADO-RS"
+          "application/dicom"
         ],
         "address": "https://pacs.hospital.org/dicomweb"
       }
@@ -331,7 +331,7 @@
           }
         ],
         "payloadMimeType": [
-          "DICOM QIDO-RS"
+          "application/dicom"
         ],
         "address": "https://pacs.hospital.org/dicomweb"
       }
@@ -364,7 +364,7 @@
           }
         ],
         "payloadMimeType": [
-          "DICOM STOW-RS"
+          "application/dicom"
         ],
         "address": "https://pacs.hospital.org/dicomweb"
       }
@@ -397,7 +397,7 @@
           }
         ],
         "payloadMimeType": [
-          "DICOM STOW-RS"
+          "application/dicom"
         ],
         "address": "https://pacs.hospital.org/dicomweb"
       }
@@ -430,7 +430,7 @@
           }
         ],
         "payloadMimeType": [
-          "DICOM WADO-URI"
+          "application/dicom"
         ],
         "address": "https://pacs.hospital.org/wadoUri"
       }
@@ -463,7 +463,7 @@
           }
         ],
         "payloadMimeType": [
-          "IHE IID"
+          "application/dicom"
         ],
         "address": "https://pacs.hospital.org/IHEInvokeImageDisplay"
       }

--- a/lib/fhir_models/examples/json/provenance-example-sig.json
+++ b/lib/fhir_models/examples/json/provenance-example-sig.json
@@ -35,7 +35,7 @@
           ]
         }
       ],
-      "whoUri": "mailto://hhd@ssa.gov"
+      "whoUri": "mailto:hhd@ssa.gov"
     }
   ],
   "signature": [

--- a/lib/fhir_models/examples/xml/capabilitystatement-example.xml
+++ b/lib/fhir_models/examples/xml/capabilitystatement-example.xml
@@ -211,7 +211,7 @@
 		<!--   this is the important element: a reference to a published document profile 
        note that this is a version specific reference.  -->
 		<profile>
-			<reference value="http://fhir.hl7.org/base/Profilebc054d23-75e1-4dc6-aca5-838b6b1ac81d/_history/b5fdd9fc-b021-4ea1-911a-721a60663796"/>
+			<reference value="http://fhir.hl7.org/StructureDefinition/Profilebc054d23-75e1-4dc6-aca5-838b6b1ac81d/_history/b5fdd9fc-b021-4ea1-911a-721a60663796"/>
 		</profile>
 	</document>
 </CapabilityStatement>

--- a/lib/fhir_models/examples/xml/claim-example-oral-contained-identifier.xml
+++ b/lib/fhir_models/examples/xml/claim-example-oral-contained-identifier.xml
@@ -99,7 +99,7 @@
     <sequence value="1"/>
     <focal value="true"/>
     <coverage>
-	  <reference value="http://www.jurisdiction.com/nationalplan/123AB345"/>
+	  <reference value="http://www.jurisdiction.com/Coverage/123AB345"/>
     </coverage>
   </insurance>
   

--- a/lib/fhir_models/examples/xml/dataelement-example.xml
+++ b/lib/fhir_models/examples/xml/dataelement-example.xml
@@ -254,7 +254,7 @@
 		</binding>
 		<mapping>
       <identity value="fhir"/>
-      <language value="application/xquery"/>
+      <language value="application/xml"/>
       <map value="return f:/Patient/f:gender"/>
     </mapping>
 	</element>

--- a/lib/fhir_models/examples/xml/endpoint-examples-general-template.xml
+++ b/lib/fhir_models/examples/xml/endpoint-examples-general-template.xml
@@ -209,7 +209,7 @@
             <code value="CDA-EventSummary"/>
           </coding>
         </payloadType>
-        <payloadMimeType value="PDF"/>
+        <payloadMimeType value="application/pdf"/>
         <address value="https://sqlonfhir-dstu2.azurewebsites.net/fhir"/>
       </Endpoint>
     </resource>
@@ -244,7 +244,7 @@
             <code value="REF-I12"/>
           </coding>
         </payloadType>
-        <payloadMimeType value="HL7v2"/>
+        <payloadMimeType value="application/fhir+json"/>
         <address value="127.0.0.1"/>
       </Endpoint>
     </resource>
@@ -279,7 +279,7 @@
             <code value="CDA-EventSummary"/>
           </coding>
         </payloadType>
-        <payloadMimeType value="XDA/XDS"/>
+        <payloadMimeType value="application/xml"/>
         <address value="https://open.epic.com/Interface/XDS.b"/>
       </Endpoint>
     </resource>
@@ -314,7 +314,7 @@
             <code value="varies (application/dicom, application/dicom+xml, image/jpeg, and many more)"/>
           </coding>
         </payloadType>
-        <payloadMimeType value="DICOM WADO-RS"/>
+        <payloadMimeType value="application/dicom"/>
         <address value="https://pacs.hospital.org/dicomweb"/>
       </Endpoint>
     </resource>
@@ -349,7 +349,7 @@
             <code value="varies (application/dicom, application/dicom+xml, image/jpeg, and many more)"/>
           </coding>
         </payloadType>
-        <payloadMimeType value="DICOM QIDO-RS"/>
+        <payloadMimeType value="application/dicom"/>
         <address value="https://pacs.hospital.org/dicomweb"/>
       </Endpoint>
     </resource>
@@ -384,7 +384,7 @@
             <code value="varies (application/dicom, application/dicom+xml, image/jpeg, and many more)"/>
           </coding>
         </payloadType>
-        <payloadMimeType value="DICOM STOW-RS"/>
+        <payloadMimeType value="application/dicom"/>
         <address value="https://pacs.hospital.org/dicomweb"/>
       </Endpoint>
     </resource>
@@ -419,7 +419,7 @@
             <code value="varies (application/dicom, application/dicom+xml, image/jpeg, and many more)"/>
           </coding>
         </payloadType>
-        <payloadMimeType value="DICOM STOW-RS"/>
+        <payloadMimeType value="application/dicom"/>
         <address value="https://pacs.hospital.org/dicomweb"/>
       </Endpoint>
     </resource>
@@ -454,7 +454,7 @@
             <code value="varies (application/dicom, application/dicom+xml, image/jpeg, and many more)"/>
           </coding>
         </payloadType>
-        <payloadMimeType value="DICOM WADO-URI"/>
+        <payloadMimeType value="application/dicom"/>
         <address value="https://pacs.hospital.org/wadoUri"/>
       </Endpoint>
     </resource>
@@ -489,7 +489,7 @@
             <code value="varies (application/dicom, application/dicom+xml, image/jpeg, and many more)"/>
           </coding>
         </payloadType>
-        <payloadMimeType value="IHE IID"/>
+        <payloadMimeType value="application/dicom"/>
         <address value="https://pacs.hospital.org/IHEInvokeImageDisplay"/>
       </Endpoint>
     </resource>

--- a/lib/fhir_models/examples/xml/provenance-example-sig.xml
+++ b/lib/fhir_models/examples/xml/provenance-example-sig.xml
@@ -36,7 +36,7 @@
     <!--  very often, the user won't have a known system - these aren't available 
       for security system log ons. But where you can define it, you should.
       Most of the time the userId is fully qualfied such as an email address	   -->
-    <whoUri value="mailto://hhd@ssa.gov"/>
+    <whoUri value="mailto:hhd@ssa.gov"/>
   </agent>
    <signature>
   <!--  verification signature  -->

--- a/lib/fhir_models/fhir_ext/structure_definition.rb
+++ b/lib/fhir_models/fhir_ext/structure_definition.rb
@@ -15,6 +15,20 @@ module FHIR
     #                            Profile Validation
     # -------------------------------------------------------------------------
 
+    class << self; attr_accessor :vs_validators end
+    @vs_validators = {}
+    def self.validates_vs(valueset_uri, &validator_fn)
+      @vs_validators[valueset_uri] = validator_fn
+    end
+
+    def self.clear_validates_vs(valueset_uri)
+      @vs_validators.delete valueset_uri
+    end
+
+    def self.clear_all_validates_vs
+      @vs_validators = {}
+    end
+
     def validates_resource?(resource)
       validate_resource(resource).empty?
     end
@@ -147,6 +161,7 @@ module FHIR
       if !element.type.empty? && element.path != id
         # element.type not being empty implies data_type_found != nil, for valid profiles
         codeable_concept_pattern = element.pattern && element.pattern.is_a?(FHIR::CodeableConcept)
+        codeable_concept_binding = element.binding
         matching_pattern = false
         nodes.each do |value|
           matching_type = 0
@@ -169,26 +184,60 @@ module FHIR
             temp_messages += @errors
             @errors = temp
           end
-          if verified_extension || verified_data_type
-            matching_type += 1
-            if data_type_found == 'code' # then check the binding
-              unless element.binding.nil?
-                matching_type += check_binding_element(element, value)
+          if data_type_found && (verified_extension || verified_data_type)
+          matching_type += 1
+          if data_type_found == 'code' # then check the binding
+            unless element.binding.nil?
+              matching_type += check_binding_element(element, value)
+            end
+          elsif data_type_found == 'CodeableConcept' && codeable_concept_pattern
+            vcc = FHIR::CodeableConcept.new(value)
+            pattern = element.pattern.coding
+            pattern.each do |pcoding|
+              vcc.coding.each do |vcoding|
+                matching_pattern = true if vcoding.system == pcoding.system && vcoding.code == pcoding.code
               end
-            elsif data_type_found == 'CodeableConcept' && codeable_concept_pattern
-              vcc = FHIR::CodeableConcept.new(value)
-              pattern = element.pattern.coding
-              pattern.each do |pcoding|
-                vcc.coding.each do |vcoding|
-                  matching_pattern = true if vcoding.system == pcoding.system && vcoding.code == pcoding.code
+            end
+          elsif data_type_found == 'CodeableConcept' && codeable_concept_binding
+            binding_issues =
+              if element.binding.strength == 'extensible'
+                @warnings
+              elsif element.binding.strength == 'required'
+                @errors
+              else # e.g., example-strength or unspecified
+                [] # Drop issues errors on the floor, in throwaway array
+              end
+
+            valueset_uri = element.binding && element.binding.valueSetReference && element.binding.valueSetReference.reference
+            vcc = FHIR::CodeableConcept.new(value)
+            if valueset_uri && self.class.vs_validators[valueset_uri]
+              check_fn = self.class.vs_validators[valueset_uri]
+              has_valid_code = vcc.coding && vcc.coding.any? { |c| check_fn.call(c) }
+              unless has_valid_code
+                binding_issues << "#{describe_element(element)} has no codings from #{valueset_uri}. Codings evaluated: #{vcc.to_json}"
+              end
+            end
+
+            unless has_valid_code
+              vcc.coding.each do |c|
+                check_fn = self.class.vs_validators[c.system]
+                if check_fn && !check_fn.call(c)
+                  binding_issues << "#{describe_element(element)} has no codings from it's specified system: #{c.system}.  "\
+                                    "Codings evaluated: #{vcc.to_json}"
                 end
               end
-            elsif data_type_found == 'String' && !element.maxLength.nil? && (value.size > element.maxLength)
-              @errors << "#{describe_element(element)} exceed maximum length of #{element.maxLength}: #{value}"
             end
-          else
-            temp_messages << "#{describe_element(element)} is not a valid #{data_type_found}: '#{value}'"
+
+          elsif data_type_found == 'String' && !element.maxLength.nil? && (value.size > element.maxLength)
+            @errors << "#{describe_element(element)} exceed maximum length of #{element.maxLength}: #{value}"
           end
+        elsif data_type_found
+          temp_messages << "#{describe_element(element)} is not a valid #{data_type_found}: '#{value}'"
+        else
+          # we don't know the data type... so we say "OK"
+          matching_type += 1
+          @warnings >> "Unable to guess data type for #{describe_element(element)}"
+        end
 
           if matching_type <= 0
             @errors += temp_messages

--- a/test/unit/json_validation_test.rb
+++ b/test/unit/json_validation_test.rb
@@ -27,7 +27,7 @@ class JsonValidationTest < Test::Unit::TestCase
       File.open("#{ERROR_DIR}/#{example_name}.err", 'w:UTF-8') { |file| file.write(JSON.pretty_unparse(errors)) }
       File.open("#{ERROR_DIR}/#{example_name}.json", 'w:UTF-8') { |file| file.write(input_json) }
     end
-    assert errors.empty?, 'Resource failed to validate.'
+    assert errors.empty?, "Resource failed to validate: #{errors}"
     # check memory
     before = check_memory
     resource = nil


### PR DESCRIPTION
This pulls in the major recent updates from fhir_dstu2_models.  This does not pull in every minor diff, but focuses on the features and updates added in the last six months or so.

- https://github.com/fhir-crucible/fhir_models/commit/9c00217c8fec10fdde6cb32aa9781cf1165d7066 aligns with https://github.com/fhir-crucible/fhir_dstu2_models/pull/15 and updates usages of deprecated `BigDecimal` methods
- https://github.com/fhir-crucible/fhir_models/commit/85f3ffe4d679a6c7b435ae25c3d6e79c968a3960 aligns with https://github.com/fhir-crucible/fhir_dstu2_models/pull/12 and fixes an issue where `Backbone` elements weren't followed in validation
- https://github.com/fhir-crucible/fhir_models/commit/78bd4f7fd17e713354a787bd9231a60be244df14 fixes issues in fixtures that were exposed by the previous commit
- https://github.com/fhir-crucible/fhir_models/commit/6c08227bca0ff046eca7aa0c50d5bf5285ce3847 adds valueset and code system validation and a few tests to exercise it (aligns with https://github.com/fhir-crucible/fhir_dstu2_models/pull/10 and https://github.com/fhir-crucible/fhir_dstu2_models/pull/11)
- https://github.com/fhir-crucible/fhir_models/commit/947466a1c13430c476704fb0cd91bad7afb512f1 aligns with https://github.com/fhir-crucible/fhir_dstu2_models/pull/14

Still want to go through and make another PR for other changes before this time frame, but for the sake of time and making it more digestible we can start reviewing these.