### PR TITLE
Update prune

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ Gemfile.lock
 .ruby-version
 .ruby-gemset
 tmp/
+
+# User-specific
+.idea

--- a/lib/fhir_models/bootstrap/hashable.rb
+++ b/lib/fhir_models/bootstrap/hashable.rb
@@ -16,7 +16,7 @@ module FHIR
           end
         end
       end
-      hash = prune(hash)
+      hash = prune(hash) || {}
       hash['resourceType'] = resourceType if respond_to?(:resourceType)
       hash
     end

--- a/lib/fhir_models/bootstrap/hashable.rb
+++ b/lib/fhir_models/bootstrap/hashable.rb
@@ -16,26 +16,27 @@ module FHIR
           end
         end
       end
-      hash = prune(hash) || {}
+      hash = prune(hash)
       hash['resourceType'] = resourceType if respond_to?(:resourceType)
       hash
     end
 
     def prune(thing)
+      # Inspired by active-support `blank` but in our case false isn't blank ...
+      # https://github.com/rails/rails/blob/v5.2.3/activesupport/lib/active_support/core_ext/object/blank.rb
+      blank = ->(obj) { obj.respond_to?(:empty?) ? obj.empty? : obj.nil? }
       if thing.is_a?(Array)
         return nil if thing.empty?
         thing.map! { |i| prune(i) }
-        thing.compact!
-        return nil if thing.empty?
+        thing.reject!(&blank)
       elsif thing.is_a?(Hash)
-        return nil if thing.empty?
+        return {} if thing.empty?
         thing.each do |key, value|
           thing[key] = prune(value)
         end
         thing.delete_if do |_key, value|
-          value.nil?
+          blank.call(value)
         end
-        return nil if thing.empty?
       end
       thing
     end

--- a/test/unit/hashable_test.rb
+++ b/test/unit/hashable_test.rb
@@ -1,0 +1,10 @@
+require_relative '../test_helper'
+class HashableTest < Test::Unit::TestCase
+
+def test_to_hash
+  patient = FHIR::Patient.new
+  patient_hash = patient.to_hash
+  assert patient_hash.is_a?(Hash)
+end
+
+end


### PR DESCRIPTION
The `prune` method in `Hashable` could return `nil` when a hash is passed in, causing an exception to be thrown by the `to_hash` method which expects a hash.

https://github.com/fhir-crucible/fhir_models/blob/71669e5199ba36c66e474503ca21de382a165a65/lib/fhir_models/bootstrap/hashable.rb#L19-L20

This PR updates `prune` to return the type of object it was provided.