### PR TITLE
Note from_contents functionality - don't merge

### DIFF
--- a/bad_capability.json
+++ b/bad_capability.json
@@ -1,0 +1,19 @@
+{
+  "name": "Inferno Capability Statement",
+  "status": "draft",
+  "date": "2019-07",
+  "kind": "capability",
+  "fhirVersion": "4.0.0",
+  "format": "json",
+  "rest": [
+    {
+      "mode": "server",
+      "resource": "TestScript"
+    },
+    {
+      "mode": "server",
+      "resource": "TestReport"
+    }
+  ],
+  "resourceType": "CapabilityStatement"
+}

--- a/test/unit/capability_json_test.rb
+++ b/test/unit/capability_json_test.rb
@@ -1,0 +1,10 @@
+require_relative '../test_helper'
+
+class CapJsonTest < Test::Unit::TestCase
+  def test_failing_capability_json
+    json = File.read('bad_capability.json')
+    cap = FHIR.from_contents(json)
+    puts "json: " + cap.to_json
+    assert cap.valid?
+  end
+end


### PR DESCRIPTION
Note functionality of `from_contents` function: 
When using `from_contents` for json, it will keep any conforming parts and get rid of the rest. It logs an error on the line `FHIR.from_contents(json)`, and there is no error on `cap.to_json`. In the example in bad_capability.json, the `resource` field is deleted. 