### PR TITLE
FI-301: Remove Old Code Climate Reporter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,15 +13,13 @@ GEM
     ast (2.4.0)
     bcp47 (0.3.3)
       i18n
-    codeclimate-test-reporter (1.0.9)
-      simplecov (<= 0.13)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     coolline (0.5.0)
       unicode_utils (~> 1.4)
     date_time_precision (0.8.1)
     diff-lcs (1.3)
-    docile (1.1.5)
+    docile (1.3.2)
     ffi (1.11.1)
     formatador (0.2.5)
     guard (2.15.0)
@@ -103,8 +101,8 @@ GEM
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
     shellany (0.0.1)
-    simplecov (0.13.0)
-      docile (~> 1.1.0)
+    simplecov (0.17.0)
+      docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
@@ -120,7 +118,6 @@ PLATFORMS
 
 DEPENDENCIES
   bundler
-  codeclimate-test-reporter
   fhir_models!
   guard-rspec
   guard-test

--- a/fhir_models.gemspec
+++ b/fhir_models.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '~> 0.17.0'
   spec.add_development_dependency 'nokogiri-diff'
   spec.add_development_dependency 'rubocop', '0.67'
-  spec.add_development_dependency 'codeclimate-test-reporter'
   spec.add_development_dependency 'guard-rspec'
   spec.add_development_dependency 'guard-test'
 end


### PR DESCRIPTION
Remove the old code climate reporter which was replaced in https://github.com/fhir-crucible/fhir_models/pull/58.