### PR TITLE
FI-332 Allow Initialization of Resources with a single FHIR::Model instance as the element value

### DIFF
--- a/lib/fhir_models/bootstrap/hashable.rb
+++ b/lib/fhir_models/bootstrap/hashable.rb
@@ -108,7 +108,6 @@ module FHIR
       begin
         obj = klass.new(child)
       rescue => exception
-        # TODO: this appears to be a dead code branch
         # TODO: should this re-raise the exception if encountered instead of silently swallowing it?
         FHIR.logger.error("Unable to inflate embedded class #{klass}\n#{exception.backtrace}")
       end

--- a/lib/fhir_models/bootstrap/hashable.rb
+++ b/lib/fhir_models/bootstrap/hashable.rb
@@ -68,11 +68,9 @@ module FHIR
         if !klass.nil? && !value.nil?
           # handle array of objects
           if value.is_a?(Array)
-            value = value.map do |child|
-              child.is_a?(FHIR::Model) ? child : make_child(child, klass)
-            end
+            value = value.map { |child| make_child(child, klass) }
           else # handle single object
-            value = make_child(value, klass) unless value.is_a?(FHIR::Model)
+            value = make_child(value, klass)
             # if there is only one of these, but cardinality allows more, we need to wrap it in an array.
             value = [value] if value && (meta['max'] > 1)
           end
@@ -95,6 +93,8 @@ module FHIR
     end
 
     def make_child(child, klass)
+      return child if child.is_a?(FHIR::Model)
+
       if child['resourceType'] && !klass::METADATA['resourceType']
         klass = begin
           FHIR.const_get(child['resourceType'])

--- a/lib/fhir_models/bootstrap/hashable.rb
+++ b/lib/fhir_models/bootstrap/hashable.rb
@@ -69,7 +69,7 @@ module FHIR
           # handle array of objects
           if value.is_a?(Array)
             value = value.map do |child|
-              child.is_a?(FHIR::Model) ? obj : make_child(child, klass)
+              child.is_a?(FHIR::Model) ? child : make_child(child, klass)
             end
           else # handle single object
             value = make_child(value, klass) unless value.is_a?(FHIR::Model)

--- a/lib/fhir_models/bootstrap/hashable.rb
+++ b/lib/fhir_models/bootstrap/hashable.rb
@@ -69,14 +69,10 @@ module FHIR
           # handle array of objects
           if value.is_a?(Array)
             value = value.map do |child|
-              obj = child
-              unless [FHIR::RESOURCES, FHIR::TYPES].flatten.include? child.class.name.gsub('FHIR::', '')
-                obj = make_child(child, klass)
-              end
-              obj
+              child.is_a?(FHIR::Model) ? obj : make_child(child, klass)
             end
           else # handle single object
-            value = make_child(value, klass)
+            value = make_child(value, klass) unless value.is_a?(FHIR::Model)
             # if there is only one of these, but cardinality allows more, we need to wrap it in an array.
             value = [value] if value && (meta['max'] > 1)
           end

--- a/spec/lib/fhir_models/bootstrap/model_spec.rb
+++ b/spec/lib/fhir_models/bootstrap/model_spec.rb
@@ -82,4 +82,18 @@ RSpec.describe 'FHIR::Model' do
     end
 
   end
+
+  describe '.new' do
+    it 'can be instatiated with a simple hash' do
+      range = FHIR::Range.new(low: {value: 18})
+      expect(range.valid?).to be_truthy
+      expect(range.low.value).to equal(18)
+    end
+
+    it 'can be instantiated with another FHIR::Model' do
+      range = FHIR::Range.new(low: FHIR::Quantity.new(value: 18))
+      expect(range.valid?).to be_truthy
+      expect(range.low.value).to equal(18)
+    end
+  end
 end


### PR DESCRIPTION
Currently a FHIR Resource can be initialized with either a simple hash or an array of objects, but not an instance of a FHIR::Model.

e.g. These work:
```ruby
range = FHIR::Range.new(low: [FHIR::Quantity.new(value: 18)])
range = FHIR::Range.new(low: {value: 18})
range.low = FHIR::Quantity.new(value: 18)
```

but this fails

```ruby
range = FHIR::Range.new(low: FHIR::Quantity.new(value: 18))
```

This PR fixes this and does some minor cleanup of the relevant code.

See the relevant issue: https://github.com/fhir-crucible/fhir_models/issues/47