### PR TITLE
Version 4.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fhir_models (4.0.2)
+    fhir_models (4.1.0)
       bcp47 (>= 0.3)
       date_time_precision (>= 0.8)
       mime-types (>= 3.0)
@@ -14,7 +14,7 @@ GEM
     bcp47 (0.3.3)
       i18n
     coderay (1.1.2)
-    concurrent-ruby (1.1.5)
+    concurrent-ruby (1.1.6)
     coolline (0.5.0)
       unicode_utils (~> 1.4)
     date_time_precision (0.8.1)
@@ -39,7 +39,7 @@ GEM
     guard-test (2.0.8)
       guard-compat (~> 1.2)
       test-unit (~> 3.0)
-    i18n (1.6.0)
+    i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.3)
     json (2.2.0)
@@ -49,9 +49,9 @@ GEM
       ruby_dep (~> 1.2)
     lumberjack (1.0.13)
     method_source (0.9.2)
-    mime-types (3.2.2)
+    mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.0331)
+    mime-types-data (3.2019.1009)
     mini_portile2 (2.4.0)
     nenv (0.3.0)
     nokogiri (1.10.8)

--- a/lib/fhir_models/version.rb
+++ b/lib/fhir_models/version.rb
@@ -1,5 +1,5 @@
 module FHIR
   module Models
-    VERSION = '4.0.2'.freeze
+    VERSION = '4.1.0'.freeze
   end
 end


### PR DESCRIPTION
Update to 4.1.0

- Fix Invalid ValueSet expansions.
- Rename FluentPath to FHIRPath
- Upgrade models to FHIR R4 v4.0.1