### PR TITLE
Fix serialization for fhir_models nested in arrays and hashes

### DIFF
--- a/lib/fhir_models/bootstrap/json.rb
+++ b/lib/fhir_models/bootstrap/json.rb
@@ -6,8 +6,8 @@ module FHIR
     #  This module includes methods to serialize or deserialize FHIR resources to and from JSON.
     #
 
-    def to_json
-      JSON.pretty_unparse(to_hash)
+    def to_json(opts = nil)
+      JSON.pretty_generate(to_hash, opts)
     end
 
     def self.from_json(json)

--- a/test/unit/json_nested_test.rb
+++ b/test/unit/json_nested_test.rb
@@ -1,0 +1,21 @@
+require_relative '../test_helper'
+
+class JsonNestedTest < Test::Unit::TestCase
+  def test_nested_in_array
+    serialized_array = [FHIR::Patient.new(id: 'foo')].to_json
+    deserialized_array = JSON.parse(serialized_array)
+    patient = deserialized_array[0]
+
+    assert_equal 'Patient', patient['resourceType']
+    assert_equal 'foo', patient['id']
+  end
+
+  def test_nested_in_hash
+    serialized_hash = { foo: FHIR::Patient.new(id: 'bar') }.to_json
+    deserialized_hash = JSON.parse(serialized_hash)
+    patient = deserialized_hash['foo']
+
+    assert_equal 'Patient', patient['resourceType']
+    assert_equal 'bar', patient['id']
+  end
+end


### PR DESCRIPTION
Before, evaluating `[FHIR::Patient.new].to_json` would raise this exception:
```
2.5.6 :005 > [FHIR::Patient.new].to_json
Traceback (most recent call last):
        4: from /Users/crowleyj/.rvm/rubies/ruby-2.5.6/bin/irb:11:in `<main>'
        3: from (irb):5
        2: from (irb):5:in `to_json'
        1: from /Users/crowleyj/.rvm/gems/ruby-2.5.6/gems/fhir_models-4.1.0/lib/fhir_models/bootstrap/json.rb:9:in `to_json'
ArgumentError (wrong number of arguments (given 1, expected 0))
```

This PR fixes that by adding an optional argument to the `to_json` method. [See here](https://makandracards.com/makandra/1727-defining-to_json-and-avoiding-errors) for more details.