### PR TITLE
FHIRPath extension bugfix

### DIFF
--- a/lib/fhir_models/fhirpath/evaluate.rb
+++ b/lib/fhir_models/fhirpath/evaluate.rb
@@ -181,7 +181,7 @@ module FHIRPath
               if exts.is_a?(Array)
                 url = nil
                 begin
-                  url = block.tree.first.gsub(/\'|\"/, '')
+                  url = block.tree.third.gsub(/\'|\"/, '')
                 rescue
                   raise 'Extension function requires a single URL as String.'
                 end


### PR DESCRIPTION
# To reproduce
Call `FHIRPath.evaluate` on a path with an [`extension`](https://www.hl7.org/fhir/fhirpath.html#functions) function, e.g. 
```ruby
FHIRPath.evaluate("Patient.extension(url = 'http://saraalert.org/StructureDefinition/preferred-contact-method').valueString", patient_json)
```
For me, this yields the following debug output:
```
D, [2021-03-02T12:12:45.386437 #58398] DEBUG -- : TOKENS: ["Patient", "extension", "(", "url", "=", "'http://saraalert.org/StructureDefinition/preferred-contact-method'", ")", "valueString"]
D, [2021-03-02T12:12:45.387313 #58398] DEBUG -- : TREE: ["Patient", :extension, ["url", :"=", "'http://saraalert.org/StructureDefinition/preferred-contact-method'"], "valueString"]
D, [2021-03-02T12:12:45.387551 #58398] DEBUG -- : DATA: ["Patient", :extension, ["url", :"=", "'http://saraalert.org/StructureDefinition/preferred-contact-method'"], "valueString"]
D, [2021-03-02T12:12:45.387900 #58398] DEBUG -- : V===> [{"extension"=>[{"url"=>"http://saraalert.org/StructureDefinition/preferred-contact-method", "valueString"=>"E-mailed Web Linkd"}], "identifier"=>[{"system"=>"http://saraalert.org/SaraAlert/state-local-id", "value"=>"asdff"}], "active"=>true, "name"=>[{"family"=>"O'Kon89", "given"=>["Malcolm94", "Bogan39"]}], "telecom"=>[{"system"=>"phone", "value"=>"(333) 333-3333", "rank"=>1}, {"system"=>"phone", "value"=>"(333) 333-3333", "rank"=>2}, {"system"=>"email", "value"=>"2966977816@fakeexample.com", "rank"=>1}], "birthDate"=>"1981-03-30", "address"=>[{"line"=>["22424 Daphne Key"], "city"=>"West Gabrielmouth", "state"=>"Maine", "postalCode"=>"24683"}, {"extension"=>[{"url"=>"http://saraalert.org/StructureDefinition/address-type", "valueString"=>"Foreign"}], "line"=>["33 Foreign rd", "Unit 4"], "city"=>"Foreign City", "district"=>"Foreign district", "state"=>"Foreign state", "postalCode"=>"98989"}], "communication"=>[{"language"=>{"coding"=>[{"system"=>"urn:ietf:bcp:47", "code"=>"en", "display"=>"English"}]}, "preferred"=>false}], "resourceType"=>"Patient"}, :extension, ["url", :"=", "'http://saraalert.org/StructureDefinition/preferred-contact-method'"], "valueString"]
D, [2021-03-02T12:12:45.388395 #58398] DEBUG -- : Evaling Extension Block....
D, [2021-03-02T12:12:45.388646 #58398] DEBUG -- : ---------------------------------------------------
D, [2021-03-02T12:12:45.388841 #58398] DEBUG -- : DATA: ["valueString"]
D, [2021-03-02T12:12:45.389040 #58398] DEBUG -- : V===> [:null]
D, [2021-03-02T12:12:45.389223 #58398] DEBUG -- : ---------------------------------------------------
D, [2021-03-02T12:12:45.389408 #58398] DEBUG -- : DATA: [:null]
D, [2021-03-02T12:12:45.389589 #58398] DEBUG -- : FUNC: [:null]
D, [2021-03-02T12:12:45.389774 #58398] DEBUG -- : MATH: [:null]
D, [2021-03-02T12:12:45.390061 #58398] DEBUG -- : MATH: [:null]
D, [2021-03-02T12:12:45.390283 #58398] DEBUG -- : MATH: [:null]
D, [2021-03-02T12:12:45.390609 #58398] DEBUG -- : MATH: [:null]
D, [2021-03-02T12:12:45.390928 #58398] DEBUG -- : EQ: [:null]
D, [2021-03-02T12:12:45.391298 #58398] DEBUG -- : EQ: [:null]
D, [2021-03-02T12:12:45.391639 #58398] DEBUG -- : LOGIC: [:null]
D, [2021-03-02T12:12:45.391930 #58398] DEBUG -- : LOGIC: [:null]
D, [2021-03-02T12:12:45.392165 #58398] DEBUG -- : IMPLIES: [:null]
D, [2021-03-02T12:12:45.392362 #58398] DEBUG -- : IMPLIES: [:null]
Unhandled reserved symbol: null
/Users/tstrassner/.rvm/gems/ruby-2.6.6/gems/fhir_models-4.1.1/lib/fhir_models/fhirpath/evaluate.rb:573:in `block in compute'
/Users/tstrassner/.rvm/gems/ruby-2.6.6/gems/fhir_models-4.1.1/lib/fhir_models/fhirpath/evaluate.rb:572:in `each'
/Users/tstrassner/.rvm/gems/ruby-2.6.6/gems/fhir_models-4.1.1/lib/fhir_models/fhirpath/evaluate.rb:572:in `compute'
/Users/tstrassner/.rvm/gems/ruby-2.6.6/gems/fhir_models-4.1.1/lib/fhir_models/fhirpath/evaluate.rb:11:in `evaluate'
```

# The fix
In the FHIRPath evaluator, when evaluating the function `extension`, it is getting the token "url" where I believe it should be getting the actual URL string, so I just modified it to get the URL string instead.