### PR TITLE
Iterate over resources

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rexml (3.2.4)
+    rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       bcp47 (>= 0.3)
       date_time_precision (>= 0.8)
       mime-types (>= 3.0)
-      nokogiri (>= 1.10.4)
+      nokogiri (>= 1.11.4)
 
 GEM
   remote: https://rubygems.org/
@@ -14,7 +14,7 @@ GEM
     bcp47 (0.3.3)
       i18n
     coderay (1.1.3)
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.9)
     coolline (0.5.0)
       unicode_utils (~> 1.4)
     date_time_precision (0.8.1)
@@ -39,7 +39,7 @@ GEM
     guard-test (2.0.8)
       guard-compat (~> 1.2)
       test-unit (~> 3.0)
-    i18n (1.8.9)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
     json (2.3.1)
@@ -51,9 +51,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
-    mini_portile2 (2.5.0)
+    mini_portile2 (2.5.3)
     nenv (0.3.0)
-    nokogiri (1.11.2)
+    nokogiri (1.11.7)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     nokogiri-diff (0.2.0)
@@ -131,7 +131,7 @@ DEPENDENCIES
   test-unit
 
 RUBY VERSION
-   ruby 2.7.2p137
+   ruby 2.5.6p201
 
 BUNDLED WITH
    2.1.4

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ $ bundle exec rake fhir:console
   )
   ```
   
-  Iterating over a resource...
+  Iterating over all elements in a resource, including nested elements...
   ```ruby
   patient.each_element do |value, metadata, path|
     puts "Info for #{path}:"

--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ $ bundle exec rake fhir:console
     'system' => 'http://unitsofmeasure.org'
   )
   ```
+  
+  Iterating over a resource...
+  ```ruby
+  patient.each_element do |value, metadata, path|
+    puts "Info for #{path}:"
+    puts "- value: #{value}"
+    puts "- type: #{metadata['type']}"
+    puts "- cardinality: #{metadata['min']}..#{metadata['max']}"
+  end
+  ```
 
   ### Validation
 

--- a/fhir_models.gemspec
+++ b/fhir_models.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'nokogiri', '>= 1.10.4'
+  spec.add_dependency 'nokogiri', '>= 1.11.4'
   spec.add_dependency 'date_time_precision', '>= 0.8'
   spec.add_dependency 'bcp47', '>= 0.3'
   spec.add_dependency 'mime-types', '>= 3.0'

--- a/lib/fhir_models/bootstrap/model.rb
+++ b/lib/fhir_models/bootstrap/model.rb
@@ -300,6 +300,26 @@ module FHIR
       valid
     end
 
+    def each_element(path = nil, &block)
+      self.class::METADATA.each do |element_name, metadata|
+        local_name = metadata.fetch :local_name, element_name
+        values = [instance_variable_get("@#{local_name}")].flatten.compact
+        next if values.empty?
+
+        values.each_with_index do |value, i|
+          child_path =
+            if path.nil?
+              element_name
+            else
+              "#{path}.#{element_name}"
+            end
+          child_path += "[#{i}]" if metadata['max'] > 1
+          yield value, metadata, child_path
+          value.each_element child_path, &block unless FHIR::PRIMITIVES.include? metadata['type']
+        end
+      end
+    end
+
     private :validate_reference_type, :check_binding_uri, :validate_field
   end
 end

--- a/lib/fhir_models/bootstrap/model.rb
+++ b/lib/fhir_models/bootstrap/model.rb
@@ -318,6 +318,7 @@ module FHIR
           value.each_element child_path, &block unless FHIR::PRIMITIVES.include? metadata['type']
         end
       end
+      self
     end
 
     private :validate_reference_type, :check_binding_uri, :validate_field

--- a/test/unit/each_element_test.rb
+++ b/test/unit/each_element_test.rb
@@ -100,4 +100,8 @@ class EachElementTest < Test::Unit::TestCase
 
     assert values_received.one? { |value| value.is_a?(FHIR::Coding) }, '#each_element did not see one Coding'
   end
+
+  def test_return_value
+    assert_equal @patient, @patient.each_element { |_, _, path| path }
+  end
 end

--- a/test/unit/each_element_test.rb
+++ b/test/unit/each_element_test.rb
@@ -1,0 +1,103 @@
+require_relative '../test_helper'
+
+class EachElementTest < Test::Unit::TestCase
+  def setup
+    @patient = FHIR::Patient.new(
+      id: 'ID',
+      name: [
+        {
+          use: 'maiden',
+          text: 'Jane Jill Roe',
+          family: 'Roe',
+          given: ['Jane', 'Jill']
+        },
+        {
+          use: 'official',
+          text: 'Jane Roe Doe',
+          family: 'Doe',
+          given: ['Jane', 'Roe']
+        }
+      ],
+      extension: [
+        {
+          url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race',
+          extension: [
+            {
+              url: 'ombCategory',
+              valueCoding:
+                {
+                  system: 'urn:oid:2.16.840.1.113883.6.238',
+                  code: '1002-5'
+                }
+            }
+          ]
+        }
+      ]
+    )
+  end
+
+  def test_all_elements_reached
+    expected_paths = [
+      'id',
+      'extension[0]',
+      'extension[0].extension[0]',
+      'extension[0].extension[0].url',
+      'extension[0].extension[0].valueCoding',
+      'extension[0].extension[0].valueCoding.system',
+      'extension[0].extension[0].valueCoding.code',
+      'extension[0].url',
+      'name[0]',
+      'name[0].use',
+      'name[0].text',
+      'name[0].family',
+      'name[0].given[0]',
+      'name[0].given[1]',
+      'name[1]',
+      'name[1].use',
+      'name[1].text',
+      'name[1].family',
+      'name[1].given[0]',
+      'name[1].given[1]'
+    ]
+
+    paths_reached = []
+    @patient.each_element { |_, _, path| paths_reached << path }
+
+    assert_equal expected_paths, paths_reached
+  end
+
+  def test_metadata_received
+    @patient.each_element { |_, metadata, _| assert metadata.is_a? Hash }
+  end
+
+  def test_values_received
+    expected_values = [
+      'ID',
+      'maiden',
+      'Jane Jill Roe',
+      'Roe',
+      'Jane',
+      'Jill',
+      'official',
+      'Jane Roe Doe',
+      'Doe',
+      'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race',
+      'ombCategory',
+      'urn:oid:2.16.840.1.113883.6.238',
+      '1002-5'
+    ]
+
+    values_received = []
+    @patient.each_element { |value, _, _| values_received << value }
+
+    expected_values.each { |value| assert values_received.include?(value), "#each_element did not see: #{value}" }
+
+    human_names = values_received.select { |value| value.is_a?(FHIR::HumanName) }
+    assert_equal 2, human_names.length, '#each_element did not see two HumanNames'
+
+    extensions = values_received.select { |value| value.is_a?(FHIR::Extension) }
+    assert_equal 2, extensions.length, '#each_element did not see two Extensions'
+
+    assert values_received.one? { |value| value.is_a?(FHIR::Coding) }, '#each_element did not see one Coding'
+  end
+end


### PR DESCRIPTION
This branch adds an `#each_element` method to `FHIR::Model` so that resources can be easily iterated over.

I also updated some dependencies to address security vulnerabilities.