### PR TITLE
FI-3180 Remove examples, schema, and expansions from gem package

### DIFF
--- a/fhir_models.gemspec
+++ b/fhir_models.gemspec
@@ -17,6 +17,10 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
+  spec.files.reject! { |file| file =~ /lib\/fhir_models\/examples|lib\/fhir_models\/definitions\/schema|lib\/fhir_models\/definitions\/valuesets/}
+  spec.files.reject! { |file| file =~ /lib\/fhir_models\/igs\/hl7.fhir.r4.core\/package_supplement\/expansions.json/}
+  spec.files.reject! { |file| file =~ /lib\/fhir_models\/igs\/hl7.fhir.r4b.core\/package_supplement\/expansions.json/}
+  spec.files.reject! { |file| file =~ /lib\/fhir_models\/igs\/hl7.fhir.r5.core\/package_supplement\/expansions.json/}
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/fhir_models.gemspec
+++ b/fhir_models.gemspec
@@ -14,13 +14,9 @@ Gem::Specification.new do |spec|
   spec.description   = %q{A Gem for handling FHIR models in ruby}
   spec.homepage      = 'https://github.com/fhir-crucible/fhir_models'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
-  end
-  spec.files.reject! { |file| file =~ /lib\/fhir_models\/examples|lib\/fhir_models\/definitions\/schema|lib\/fhir_models\/definitions\/valuesets/}
-  spec.files.reject! { |file| file =~ /lib\/fhir_models\/igs\/hl7.fhir.r4.core\/package_supplement\/expansions.json/}
-  spec.files.reject! { |file| file =~ /lib\/fhir_models\/igs\/hl7.fhir.r4b.core\/package_supplement\/expansions.json/}
-  spec.files.reject! { |file| file =~ /lib\/fhir_models\/igs\/hl7.fhir.r5.core\/package_supplement\/expansions.json/}
+  spec.files         = `git ls-files -z lib`.split("\x0")
+  spec.files.reject! { |file| file =~ /lib\/fhir_models\/examples|lib\/fhir_models\/definitions/}
+  spec.files.reject! { |file| file =~ /lib\/fhir_models\/igs\/hl7.fhir..*\.core\/package_supplement\/expansions.json/}
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/fhir_models.gemspec
+++ b/fhir_models.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{A Gem for handling FHIR models in ruby}
   spec.homepage      = 'https://github.com/fhir-crucible/fhir_models'
 
-  spec.files         = `git ls-files -z lib`.split("\x0")
+  spec.files         = `git ls-files -z lib LICENSE`.split("\x0")
   spec.files.reject! { |file| file =~ /lib\/fhir_models\/examples|lib\/fhir_models\/definitions/}
   spec.files.reject! { |file| file =~ /lib\/fhir_models\/igs\/hl7.fhir..*\.core\/package_supplement\/expansions.json/}
   spec.bindir        = 'exe'

--- a/lib/fhir_models/bootstrap/common_definitions.rb
+++ b/lib/fhir_models/bootstrap/common_definitions.rb
@@ -10,22 +10,30 @@ module FHIR
     module ClassMethods
       extend FHIR::Deprecate
 
+      def ig_resources
+        @ig_resources ||= @ig_loader.load
+      end
+
+      def cache
+        @cache ||= {}
+      end
+
+      # This method actually just sets up lazy loading to avoid having to load
+      # everything at start time.
       def load_igs(ig_file_name)
-        ig_loader = FHIR::Generator::IGLoader.new(ig_file_name)
-        @ig_resources = ig_loader.load
-        @cache = {}
+        @ig_loader = FHIR::Generator::IGLoader.new(ig_file_name)
       end
 
       def find_structure_definition(structure_defs, target_name)
         return nil if target_name.nil?
-        return @cache[target_name] if @cache[target_name]
+        return cache[target_name] if cache[target_name]
 
         definition = structure_defs.find do |sd|
           sd['id'] == target_name || sd['name'] == target_name || sd['url'] == target_name
         end
 
-        @cache[target_name] = create_structure_definition(definition) if definition
-        @cache[target_name]
+        cache[target_name] = create_structure_definition(definition) if definition
+        cache[target_name]
       end
 
       def create_structure_definition(definition)
@@ -39,12 +47,12 @@ module FHIR
       # # ----------------------------------------------------------------
 
       def primitive_types
-        @ig_resources.primitive_types
+        ig_resources.primitive_types
       end
       deprecate :get_primitive_types, :primitive_types
 
       def complex_types
-        @ig_resources.complex_types
+        ig_resources.complex_types
       end
       deprecate :get_complex_types, :complex_types
 
@@ -58,7 +66,7 @@ module FHIR
       # ----------------------------------------------------------------
 
       def resource_definitions
-        @ig_resources.resource_definitions
+        ig_resources.resource_definitions
       end
       deprecate :get_resource_definitions, :resource_definitions
 
@@ -68,7 +76,7 @@ module FHIR
       deprecate :get_resource_definition, :resource_definition
 
       def extension_definition(extension_name)
-        find_structure_definition(@ig_resources.extension_definitions, extension_name)
+        find_structure_definition(ig_resources.extension_definitions, extension_name)
       end
       deprecate :get_extension_definition, :extension_definition
 
@@ -76,7 +84,7 @@ module FHIR
       def basetype(uri)
         return nil if uri.nil?
 
-        defn = @ig_resources.profiles.detect { |x| x['url'] == uri } || @ig_resources.extension_definitions.detect { |x| x['url'] == uri }
+        defn = ig_resources.profiles.detect { |x| x['url'] == uri } || ig_resources.extension_definitions.detect { |x| x['url'] == uri }
         return nil if defn.nil?
 
         defn['type']
@@ -85,14 +93,14 @@ module FHIR
 
       # Get the StructureDefinition for a given profile.
       def profile(profile_url)
-        find_structure_definition(@ig_resources.profiles, profile_url)
+        find_structure_definition(ig_resources.profiles, profile_url)
       end
       deprecate :get_profile, :profile
 
       def profiles_for_resource(resource_name)
         return nil if resource_name.nil?
 
-        @ig_resources.profiles.select { |x| x['type'] == resource_name }
+        ig_resources.profiles.select { |x| x['type'] == resource_name }
       end
       deprecate :get_profiles_for_resource, :profile_for_resource
 
@@ -101,18 +109,18 @@ module FHIR
       # ----------------------------------------------------------------
 
       def valuesets
-        @ig_resources.get_value_sets
+        ig_resources.get_value_sets
       end
 
       def get_codes(url)
-        @ig_resources.get_codes(url)
+        ig_resources.get_codes(url)
       end
 
       # Why do we have this function?
       def get_display(system, code)
         return nil if system.nil? || code.nil?
 
-        @ig_resources.get_value_sets.each do |value_set|
+        ig_resources.get_value_sets.each do |value_set|
           if value_set['expansion'] && value_set['expansion']['contains']
             value_set['expansion']['contains'].each do |contain|
               return contain['display'] if contain['system'] == system && contain['code'] == code
@@ -132,7 +140,7 @@ module FHIR
       # ----------------------------------------------------------------
 
       def self.search_parameters(type_name)
-        @ig_resources.get_search_parameters(type_name)
+        ig_resources.get_search_parameters(type_name)
       end
       deprecate :get_search_parameters, :search_parameters
     end


### PR DESCRIPTION
Removes the following files from the gem package:
- The entire `examples` directory
- The entire `definitions/schema` directory
- Each of the `expansions.json` of each version


The built gem has gone from 52MB -> 39 MB.  Still a lot, but at least it is a reduction.  It also built/installed a LOT faster than it has in the past for me.

I have built the gem, installed it, and ran the unit tests in both models and client.  Models unit tests uses `require` instead of `require_relative`, so I believe it attempts to use the installed gem before the local repo, but I'm not familiar enough with ruby to confirm this.  In any case, both pass, but I'm not sure if there is more that should be done to verify this isn't a breaking change.