### PR TITLE
Version 5.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fhir_models (4.4.0)
+    fhir_models (5.0.0)
       bcp47 (>= 0.3)
       date_time_precision (>= 0.8)
       mime-types (>= 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fhir_models (4.3.0)
+    fhir_models (4.4.0)
       bcp47 (>= 0.3)
       date_time_precision (>= 0.8)
       mime-types (>= 3.0)
@@ -57,7 +57,7 @@ GEM
     method_source (1.0.0)
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2024.0507)
+    mime-types-data (3.2024.0702)
     mini_portile2 (2.8.6)
     nenv (0.3.0)
     nokogiri (1.16.5)

--- a/lib/fhir_models/version.rb
+++ b/lib/fhir_models/version.rb
@@ -1,5 +1,5 @@
 module FHIR
   module Models
-    VERSION = '4.3.0'.freeze
+    VERSION = '4.4.0'.freeze
   end
 end

--- a/lib/fhir_models/version.rb
+++ b/lib/fhir_models/version.rb
@@ -1,5 +1,5 @@
 module FHIR
   module Models
-    VERSION = '4.4.0'.freeze
+    VERSION = '5.0.0'.freeze
   end
 end


### PR DESCRIPTION
bump version to 5.0.0 before building and publishing the gem with R4B and R5 support.

Let me know if I should `bundle update` or anything, not sure if we only want to do that when there are vulnerabilities