### PR TITLE
Remove tgz files from gem package

### DIFF
--- a/fhir_models.gemspec
+++ b/fhir_models.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z lib LICENSE`.split("\x0")
   spec.files.reject! { |file| file =~ /lib\/fhir_models\/examples|lib\/fhir_models\/definitions/}
   spec.files.reject! { |file| file =~ /lib\/fhir_models\/igs\/hl7.fhir..*\.core\/package_supplement\/expansions.json/}
+  spec.files.reject! { |file| file =~ /.*\.tgz$/}
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/fhir_models.gemspec
+++ b/fhir_models.gemspec
@@ -15,8 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/fhir-crucible/fhir_models'
 
   spec.files         = `git ls-files -z lib LICENSE`.split("\x0")
-  spec.files.reject! { |file| file =~ /lib\/fhir_models\/examples|lib\/fhir_models\/definitions/}
-  spec.files.reject! { |file| file =~ /lib\/fhir_models\/igs\/hl7.fhir..*\.core\/package_supplement\/expansions.json/}
+  spec.files.reject! { |file| file =~ /lib\/fhir_models\/examples|lib\/fhir_models\/definitions|lib\/fhir_models\/igs/}
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']


### PR DESCRIPTION
There is a considerable file size increase for 5.0.0:

[5.0.0](https://rubygems.org/gems/fhir_models/versions/5.0.0) - October 14, 2024 (36.7 MB)
[4.3.0](https://rubygems.org/gems/fhir_models/versions/4.3.0) - May 30, 2024 (7.51 MB)

Mainly due to the inclusion of compressed artifacts:

- [hl7.fhir.r4.core.tgz](https://github.com/fhir-crucible/fhir_models/commit/3a964f75102b0ee69f2b8191c80f9ecd6ca91bab#diff-c0ff0624476e0ee9430aea7b151f6618c3d0ca6ab05689d29f25322b1264dc78)
- [hl7.fhir.r4b.core.tgz](https://github.com/fhir-crucible/fhir_models/commit/3a964f75102b0ee69f2b8191c80f9ecd6ca91bab#diff-c68fdc42bd1b99c0d1ea7c357b9891427ce0a1613a9bca88fb23a02f16fe0aad)
- [hl7.fhir.r5.core.tgz](https://github.com/fhir-crucible/fhir_models/commit/1924f6bcf5432708e4df8418c5ac119b4fbc80db)

Avoid it by excluding these files from the final gem package.