### PR TITLE
Add ostruct gem dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
+    ostruct (0.6.3)
     parallel (1.26.3)
     parser (3.3.11.1)
       ast (~> 2.4.1)
@@ -171,6 +172,7 @@ DEPENDENCIES
   guard-rspec
   guard-test
   nokogiri-diff
+  ostruct
   parallel (= 1.26.3)
   pry
   pry-byebug

--- a/fhir_models.gemspec
+++ b/fhir_models.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'ostruct'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-coolline'
   spec.add_development_dependency 'test-unit'


### PR DESCRIPTION
Fixes: 2b0bdcf0 ("require 'ostruct' added to build mock objects. Was autoloaded in previous ruby versions but has to be explicitly stated in ruby 3.3")

# Summary

Add a missing testing dependency on the ostruct gem.

# Testing Guidance

