### PR TITLE
Silence deprecation warnings

### DIFF
--- a/lib/fhir_models/tasks/tasks.rake
+++ b/lib/fhir_models/tasks/tasks.rake
@@ -141,7 +141,7 @@ namespace :fhir do
   task :invariants, [] do |_t, _args|
     # create a generator and load the definitions
     d = FHIR::Definitions
-    defs = d.get_complex_types + d.get_resource_definitions
+    defs = d.complex_types + d.resource_definitions
     invariants = {}
     defs.each do |structure_definition|
       structure_definition['snapshot']['element'].each do |element|


### PR DESCRIPTION
# Summary

Silence deprecation warnings when running:

    rake fhir:invariants

By replacing:

    get_resource_definitions -> resource_definitions
    get_complex_types -> complex_types

These methods were deprecated in 3639c034 ("deprecate 'get_' methods and cleanup implementation of some methods.  Use memorizing when appropriate.")

# Testing Guidance

    rake fhir:invariants

