### PR TITLE
Fix tests by adding missing spaces

### DIFF
--- a/test/unit/profile_validation_test.rb
+++ b/test/unit/profile_validation_test.rb
@@ -265,11 +265,11 @@ class ProfileValidationTest < Test::Unit::TestCase
 
     sd.errors = []
     sd.send(:verify_element, element, 'cc' => { 'coding' => [{ 'system' => 'http://ncimeta.nci.nih.gov', 'code' => 'C2222222' }] }) # wrong code
-    assert_equal("cc CodeableConcept did not match defined pattern: {\"coding\"=>[{\"system\"=>\"http://ncimeta.nci.nih.gov\", \"code\"=>\"C2004062\"}]}", sd.errors[0])
+    assert_equal("cc CodeableConcept did not match defined pattern: {\"coding\" => [{\"system\" => \"http://ncimeta.nci.nih.gov\", \"code\" => \"C2004062\"}]}", sd.errors[0])
 
     sd.errors = []
     sd.send(:verify_element, element, 'cc' => { 'coding' => [{ 'system' => 'http://hl7.org/fhir/sid/icd-10', 'code' => 'Q841' }] }) # completely different
-    assert_equal("cc CodeableConcept did not match defined pattern: {\"coding\"=>[{\"system\"=>\"http://ncimeta.nci.nih.gov\", \"code\"=>\"C2004062\"}]}", sd.errors[0])
+    assert_equal("cc CodeableConcept did not match defined pattern: {\"coding\" => [{\"system\" => \"http://ncimeta.nci.nih.gov\", \"code\" => \"C2004062\"}]}", sd.errors[0])
   end
 
   def test_invalid_value_per_type


### PR DESCRIPTION
Fixes: d3d72937 ("adding some unit tests")

# Summary

Add missing spaces in tests that were causing failures.

# Testing Guidance

    rake
